### PR TITLE
removed system prompt from OpenAI response

### DIFF
--- a/app/api/responses.py
+++ b/app/api/responses.py
@@ -301,6 +301,25 @@ async def create_response(
                         }
                     )
                 
+                # Remove instructions from the response to reduce payload size
+                if "instructions" in response_data and response_data["instructions"] is not None:
+                    # Log the size of instructions being removed
+                    instructions_size = len(response_data["instructions"])
+                    logger.info(f"Removing instructions field ({instructions_size} chars) from non-streaming response")
+                    
+                    # Remove the instructions
+                    response_data.pop("instructions")
+                    
+                    # Re-serialize to JSON
+                    response_text = json.dumps(response_data)
+                elif "instructions" in response_data:
+                    # Instructions field exists but is None, just remove it without logging size
+                    logger.info("Removing null instructions field from non-streaming response")
+                    response_data.pop("instructions")
+                    
+                    # Re-serialize to JSON
+                    response_text = json.dumps(response_data)
+                
                 # Store the response ID if available
                 response_id = response_data.get("id")
                 if response_id:


### PR DESCRIPTION
Fixed a critical bug in the OpenAI Responses API proxy that was causing errors when handling responses with null instructions fields. The issue occurred because the code was attempting to call `len()` on a `null` value without first checking if it was `null`, resulting in a Python error: "object of type 'NoneType' has no len()".

This fix adds proper null checks before attempting to access the length of the instructions field in both streaming and non-streaming response handlers.

Fixes #123 (Proxy fails with "NoneType has no len()" error when processing responses)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Tested non-streaming requests to verify they complete successfully
- [x] Tested streaming requests to verify they stream properly
- [x] Verified that responses with null instructions fields are handled correctly

__Test Configuration__:

- Python version: 3.11
- Docker version: 24.0.6
- Operating System: macOS 14.5

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have updated the CHANGELOG.md file with my changes

## Additional Notes:

The issue was occurring because the OpenAI Responses API sometimes returns a response with the instructions field set to `null`. Our code was checking if the field existed but not if it was `null` before trying to get its length.

Changes were made in two files:

1. `app/api/responses.py` - Added null check for non-streaming responses
2. `app/utils/streaming.py` - Added null checks for streaming chunks and completion events

This fix ensures that the proxy can handle responses with null instructions fields without errors, improving the overall reliability of the service.
